### PR TITLE
Fix exception passing wrong number of arguments

### DIFF
--- a/lib/cookie_law.rb
+++ b/lib/cookie_law.rb
@@ -8,7 +8,7 @@ module CookieLaw
   COOKIE_NAME = 'cl_accepted'
   DEFAULT_EXPIRATION = 365 # In Days
   ACCEPT_ON_SCROLL = false
-  ACCEPT_ON_ANY_LINK = true
+  ACCEPT_ON_ANY_LINK = false
   DEFAULT_SCROLL_HEIGHT = 180
 
   def self.configuration

--- a/lib/cookie_law.rb
+++ b/lib/cookie_law.rb
@@ -7,7 +7,7 @@ require 'cookie_law/missing_policy_link_exception'
 module CookieLaw
   COOKIE_NAME = 'cl_accepted'
   DEFAULT_EXPIRATION = 365 # In Days
-  ACCEPT_ON_SCROLL = true
+  ACCEPT_ON_SCROLL = false
   ACCEPT_ON_ANY_LINK = true
   DEFAULT_SCROLL_HEIGHT = 180
 

--- a/lib/cookie_law/helper.rb
+++ b/lib/cookie_law/helper.rb
@@ -9,7 +9,7 @@ module CookieLaw::Helper
     begin
       JSON.parse(cookies[CookieLaw.cookie_name])['accepted']
     rescue JSON::ParserError
-      cookies.delete[CookieLaw.cookie_name]
+      cookies.delete(CookieLaw.cookie_name)
       false
     end
   end

--- a/lib/cookie_law/version.rb
+++ b/lib/cookie_law/version.rb
@@ -1,3 +1,3 @@
 module CookieLaw
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/lib/cookie_law/version.rb
+++ b/lib/cookie_law/version.rb
@@ -1,3 +1,3 @@
 module CookieLaw
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
cookies.delete takes args with parentesis.